### PR TITLE
Refs #45721 #46143,feat: add confirm box before send email

### DIFF
--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -115,8 +115,8 @@
   margin: 0 !important;
 }
 </style>
-<div id="dialog-confirm-email" title="{ts}你確定要寄送電子郵件?{/ts}" style="display:none;">
-  <p>{ts}發送此電子郵件後將無法復原。您確定要繼續嗎？{/ts}</p>
+<div id="dialog-confirm-email" title="{ts}Confirm Send Email?{/ts}" style="display:none;">
+  <p>{ts}Are you sure you want to continue?{/ts}</p>
 </div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
@@ -171,7 +171,7 @@ cj(document).ready(function() {
     modal: true,
     dialogClass: 'email-confirm-dialog',
     buttons: {
-      '{/literal}{ts}確定{/ts}{literal}': function() {
+      '{/literal}{ts}Confirm{/ts}{literal}': function() {
         cj(this).dialog('close');
         if (clickedBtn) {
           // Remove our handler then use native DOM click to submit with button value in POST

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -105,6 +105,19 @@
 {if $suppressedEmails > 0}
    {ts count=$suppressedEmails plural='Email will NOT be sent to %count contacts.'}Email will NOT be sent to %count contact.{/ts}
 {/if}
+{* Confirmation dialog - prevent accidental email send *}
+<style>
+.email-confirm-dialog {
+  position: fixed !important;
+  top: 210px ;
+  left: 50% ;
+  transform: translate(-50%, -50%) !important;
+  margin: 0 !important;
+}
+</style>
+<div id="dialog-confirm-email" title="{ts}你確定要寄送電子郵件?{/ts}" style="display:none;">
+  <p>{ts}發送此電子郵件後將無法復原。您確定要繼續嗎？{/ts}</p>
+</div>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
 <script type="text/javascript">
@@ -144,6 +157,41 @@ cj( "#to"     ).tokenInput( toDataUrl, { prePopulate: toContact, classes: tokenC
 cj( "#cc_id"  ).tokenInput( sourceDataUrl, { prePopulate: ccContact, classes: tokenClass, hintText: hintText });
 cj( "#bcc_id" ).tokenInput( sourceDataUrl, { prePopulate: bccContact, classes: tokenClass, hintText: hintText });
 cj( 'ul.token-input-list-facebook, div.token-input-dropdown-facebook' ).css( 'width', '450px' );
+</script>
+{/literal}
+{literal}
+<script type="text/javascript">
+cj(document).ready(function() {
+  var clickedBtn = null;
+
+  cj('#dialog-confirm-email').dialog({
+    autoOpen: false,
+    resizable: false,
+    width: 450,
+    modal: true,
+    dialogClass: 'email-confirm-dialog',
+    buttons: {
+      '{/literal}{ts}確定{/ts}{literal}': function() {
+        cj(this).dialog('close');
+        if (clickedBtn) {
+          // Remove our handler then use native DOM click to submit with button value in POST
+          cj(clickedBtn).off('click.emailConfirm');
+          clickedBtn.click();
+        }
+      },
+      '{/literal}{ts}Cancel{/ts}{literal}': function() {
+        cj(this).dialog('close');
+      }
+    }
+  });
+
+  cj('#_qf_Email_upload-top, #_qf_Email_upload-bottom').on('click.emailConfirm', function(e) {
+    e.preventDefault();
+    clickedBtn = this;
+    cj('#dialog-confirm-email').dialog('open');
+    return false;
+  });
+});
 </script>
 {/literal}
 {include file="CRM/common/formNavigate.tpl"}


### PR DESCRIPTION
寄送個人 Email 時，跳出確認 box 以免誤寄送

正常流程

TC-01
對應 AC：AC-1、AC-2
前置狀態：進入聯絡人 > 活動 > 新增，選擇活動類型「Email」，填寫主旨與內容
操作步驟：點擊「Send Email」，在確認對話框點擊「確認寄送」
預期結果：跳出確認對話框；確認後 Email 寄出並建立活動紀錄
例外情境

TC-02
對應 AC：AC-1、AC-3
前置狀態：填寫 Email 內容後點擊「Send Email」，跳出確認對話框
操作步驟：在確認對話框點擊「取消」
預期結果：對話框關閉，Email 未寄送，使用者仍停留在原編輯頁面
邊界情境

TC-03
對應 AC：AC-4
前置狀態：進入聯絡人 > 活動 > 新增，選擇活動類型「會議」
操作步驟：填寫後送出
預期結果：直接送出，不出現確認對話框