### PR TITLE
Refs #46074 #46347 ,feat: add track filter & export excel btn

### DIFF
--- a/CRM/Track/Page/Track.php
+++ b/CRM/Track/Page/Track.php
@@ -27,6 +27,9 @@ class CRM_Track_Page_Track extends CRM_Core_Page {
       'utmCampaign' => CRM_Utils_Request::retrieve('utm_campaign', 'String', $null),
       'utmTerm' => CRM_Utils_Request::retrieve('utm_term', 'String', $null),
       'utmContent' => CRM_Utils_Request::retrieve('utm_content', 'String', $null),
+      'referrerUrl' => CRM_Utils_Request::retrieve('referrer_url', 'String', $null),
+      'landing' => CRM_Utils_Request::retrieve('landing', 'String', $null),
+      'pageTitle' => CRM_Utils_Request::retrieve('page_title', 'String', $null),
     ];
 
     // only appear 3 month data by default
@@ -42,6 +45,13 @@ class CRM_Track_Page_Track extends CRM_Core_Page {
     if ($end = CRM_Utils_Request::retrieve('end', 'Date', $null)) {
       $params['visitDateEnd'] = $end;
     }
+    // Trigger spreadsheet export when output=csv is requested
+    $output = CRM_Utils_Request::retrieve('output', 'String', $null);
+    if ($output === 'csv') {
+      self::exportTrack($params);
+      return parent::run();
+    }
+
     if ($params['pageType'] == 'civicrm_contribution_page' && $params['pageId']) {
       // breadcrumb starter
       $breadcrumbs = [
@@ -60,6 +70,10 @@ class CRM_Track_Page_Track extends CRM_Core_Page {
     $selector = new CRM_Track_Selector_Track($params, $this->_scope);
     $selector->filters($this);
     $selector->breadcrumbs($this);
+    $this->assign('referrerTypes', CRM_Core_PseudoConstant::referrerTypes());
+    $this->assign('trackStates', CRM_Core_PseudoConstant::trackState());
+    $this->assign('pageTypes', $selector->_pageTypes);
+    $this->assign('currentPageType', $params['pageType']);
 
     $controller = new CRM_Core_Selector_Controller(
       $selector,
@@ -138,6 +152,176 @@ class CRM_Track_Page_Track extends CRM_Core_Page {
     }
 
     return parent::run();
+  }
+
+  /**
+   * Handle spreadsheet export for traffic source report.
+   * Routes to direct download or batch job based on row count.
+   *
+   * @param array $params
+   *   Filter params from run().
+   */
+  public static function exportTrack($params) {
+    global $civicrm_batch;
+
+    $rowsPerBatch = CRM_Export_BAO_Export::EXPORT_ROW_COUNT;
+    $batchThreshold = CRM_Export_BAO_Export::EXPORT_BATCH_THRESHOLD;
+    $csvThreshold = CRM_Export_BAO_Export::EXPORT_BATCH_CSV_THRESHOLD;
+    $exportMode = CRM_Core_Selector_Controller::EXPORT;
+
+    $selector = new CRM_Track_Selector_Track($params);
+    $fileName = $selector->getExportFileName();
+
+    if (empty($civicrm_batch)) {
+      // Count rows with current filter conditions
+      $countDao = $selector->getQuery('COUNT(id) as total_count');
+      $countDao->fetch();
+      $totalNumRows = (int)($countDao->total_count ?? 0);
+
+      if ($totalNumRows > $batchThreshold) {
+        // Large dataset: schedule batch job
+        $config = CRM_Core_Config::singleton();
+        $isCsv = $totalNumRows > $csvThreshold;
+
+        if ($isCsv) {
+          $fileName = str_replace('.xlsx', '.csv', $fileName);
+        }
+
+        $file = $config->uploadDir . $fileName;
+        $downloadHeader = $isCsv ? [
+          'Content-Type: text/csv',
+          'Content-Disposition: attachment;filename="' . $fileName . '"',
+        ] : [
+          'Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          'Content-Disposition: attachment;filename="' . $fileName . '"',
+        ];
+
+        $batch = new CRM_Batch_BAO_Batch();
+        $batch->start([
+          'label' => ts('Export') . ': ' . $fileName,
+          'description' => NULL,
+          'startCallback' => NULL,
+          'startCallbackArgs' => NULL,
+          'processCallback' => [__CLASS__, 'exportBatch'],
+          'processCallbackArgs' => [$params],
+          'finishCallback' => [__CLASS__, 'exportBatchFinish'],
+          'finishCallbackArgs' => NULL,
+          'exportFile' => $file,
+          'download' => ['header' => $downloadHeader, 'file' => $file],
+          'total' => $totalNumRows,
+          'processed' => 0,
+        ]);
+
+        CRM_Core_Session::setStatus(ts('Because of the large amount of data you are about to perform, we have scheduled this job for the batch process. You will receive an email notification when the work is completed.'));
+        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/admin/batch', "reset=1&id={$batch->_id}"));
+        return;
+      }
+
+      // Small dataset: direct export to browser
+      $headers = $selector->getColumnHeaders(NULL, $exportMode);
+      $config = CRM_Core_Config::singleton();
+
+      $writer = CRM_Core_Report_Excel::singleton('excel');
+      if ($config->decryptExcelOption == 0) {
+        $writer->openToBrowser($fileName);
+      }
+      else {
+        $filePath = $config->uploadDir . $fileName;
+        $writer->openToFile($filePath);
+      }
+
+      $writer->addRow($headers);
+      $offset = 0;
+      while (TRUE) {
+        $rows = $selector->getRows(CRM_Core_Action::VIEW, $offset, $rowsPerBatch, NULL, $exportMode);
+        if (empty($rows)) {
+          break;
+        }
+        foreach ($rows as $row) {
+          $writer->addRow(array_values($row));
+        }
+        $offset += $rowsPerBatch;
+        if (count($rows) < $rowsPerBatch) {
+          break;
+        }
+      }
+      $writer->close();
+
+      if ($config->decryptExcelOption != 0) {
+        CRM_Utils_File::encryptXlsxFile($filePath);
+        header('Content-type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+        header('Content-Disposition: attachment; filename=' . $fileName);
+        header('Pragma: no-cache');
+        echo file_get_contents($filePath);
+      }
+      CRM_Utils_System::civiExit();
+    }
+  }
+
+  /**
+   * Batch processCallback: write one chunk of rows to the export file.
+   *
+   * @param array $params
+   *   Filter params passed via processCallbackArgs.
+   */
+  public static function exportBatch($params) {
+    global $civicrm_batch;
+
+    $rowsPerBatch = CRM_Export_BAO_Export::EXPORT_ROW_COUNT;
+    $exportMode = CRM_Core_Selector_Controller::EXPORT;
+
+    $selector = new CRM_Track_Selector_Track($params);
+    $offset = (int)$civicrm_batch->data['processed'];
+    $exportFile = $civicrm_batch->data['exportFile'];
+    $isCsv = (strpos($exportFile, '.csv') !== FALSE);
+
+    $headers = $selector->getColumnHeaders(NULL, $exportMode);
+    $rows = $selector->getRows(CRM_Core_Action::VIEW, $offset, $rowsPerBatch, NULL, $exportMode);
+
+    if (empty($rows)) {
+      $civicrm_batch->data['isCompleted'] = TRUE;
+      return;
+    }
+
+    $rowValues = array_map('array_values', $rows);
+
+    if ($isCsv) {
+      // Write header row on first chunk, then append subsequent chunks
+      if (!is_file($exportFile)) {
+        $writer = CRM_Core_Report_Excel::singleton('csv');
+        $writer->openToFile($exportFile);
+        $writer->addRow($headers);
+        $writer->close();
+      }
+      $config = CRM_Core_Config::singleton();
+      $handle = fopen($exportFile, 'a');
+      foreach ($rowValues as $row) {
+        fputcsv($handle, $row, $config->fieldSeparator);
+      }
+      fclose($handle);
+    }
+    else {
+      CRM_Core_Report_Excel::appendExcelFile($exportFile, $headers, $rowValues);
+    }
+
+    $civicrm_batch->data['processed'] = $offset + count($rows);
+  }
+
+  /**
+   * Batch finishCallback: encrypt xlsx file if site requires it.
+   */
+  public static function exportBatchFinish() {
+    global $civicrm_batch;
+
+    $fileFullPath = $civicrm_batch->data['download']['file'];
+    $fileType = $civicrm_batch->data['download']['header'][0];
+
+    if (strstr($fileType, 'vnd.openxmlformats-officedocument.spreadsheetml.sheet')) {
+      $config = CRM_Core_Config::singleton();
+      if ($config->decryptExcelOption != 0) {
+        CRM_Utils_File::encryptXlsxFile($fileFullPath);
+      }
+    }
   }
 
   /**

--- a/CRM/Track/Page/Track.php
+++ b/CRM/Track/Page/Track.php
@@ -33,7 +33,7 @@ class CRM_Track_Page_Track extends CRM_Core_Page {
     ];
 
     // only appear 3 month data by default
-    $last3month = date('Y-m-01', strtotime('-3 month'));
+    $last3month = date('Y-m-d', strtotime('-3 month'));
     $start = CRM_Utils_Request::retrieve('start', 'Date', $null);
     if (empty($start)) {
       $this->assign('defaultStartDate', $last3month);
@@ -164,9 +164,14 @@ class CRM_Track_Page_Track extends CRM_Core_Page {
   public static function exportTrack($params) {
     global $civicrm_batch;
 
-    $rowsPerBatch = CRM_Export_BAO_Export::EXPORT_ROW_COUNT;
-    $batchThreshold = CRM_Export_BAO_Export::EXPORT_BATCH_THRESHOLD;
-    $csvThreshold = CRM_Export_BAO_Export::EXPORT_BATCH_CSV_THRESHOLD;
+    // Apply 3-month default when no start date is specified
+    if (empty($params['visitDateStart'])) {
+      $params['visitDateStart'] = date('Y-m-d', strtotime('-3 month'));
+    }
+
+    $rowsPerBatch = CRM_Export_BAO_Export::EXPORT_ROW_COUNT; //2000
+    $batchThreshold = CRM_Export_BAO_Export::EXPORT_BATCH_THRESHOLD; //10,000
+    $csvThreshold = CRM_Export_BAO_Export::EXPORT_BATCH_CSV_THRESHOLD; //100,000
     $exportMode = CRM_Core_Selector_Controller::EXPORT;
 
     $selector = new CRM_Track_Selector_Track($params);
@@ -178,10 +183,10 @@ class CRM_Track_Page_Track extends CRM_Core_Page {
       $countDao->fetch();
       $totalNumRows = (int)($countDao->total_count ?? 0);
 
-      if ($totalNumRows > $batchThreshold) {
+      if ($totalNumRows >= $batchThreshold) {
         // Large dataset: schedule batch job
         $config = CRM_Core_Config::singleton();
-        $isCsv = $totalNumRows > $csvThreshold;
+        $isCsv = $totalNumRows >= $csvThreshold;
 
         if ($isCsv) {
           $fileName = str_replace('.xlsx', '.csv', $fileName);
@@ -220,12 +225,15 @@ class CRM_Track_Page_Track extends CRM_Core_Page {
       // Small dataset: direct export to browser
       $headers = $selector->getColumnHeaders(NULL, $exportMode);
       $config = CRM_Core_Config::singleton();
+      $filePath = NULL;
 
       $writer = CRM_Core_Report_Excel::singleton('excel');
       if ($config->decryptExcelOption == 0) {
+        // AC-9: no password protection, stream directly to browser
         $writer->openToBrowser($fileName);
       }
       else {
+        // AC-8: write to temp file first so we can encrypt before sending
         $filePath = $config->uploadDir . $fileName;
         $writer->openToFile($filePath);
       }

--- a/CRM/Track/Selector/Track.php
+++ b/CRM/Track/Selector/Track.php
@@ -219,6 +219,9 @@ class CRM_Track_Selector_Track extends CRM_Core_Selector_Base implements CRM_Cor
         'rnetwork' => ts('Referrer Network'),
         'state' => ts('Visit State'),
         'entity_id' => ts('Referenced Record'),
+        'referrer_url' => ts('Referrer URL'),
+        'landing' => ts('Landing Page'),
+        'page_title' => ts('Page Name'),
         'utm_source' => 'utm_source',
         'utm_medium' => 'utm_medium',
         'utm_campaign' => 'utm_campaign',
@@ -303,6 +306,25 @@ class CRM_Track_Selector_Track extends CRM_Core_Selector_Base implements CRM_Cor
    * @return array the column headers that need to be displayed
    */
   public function &getColumnHeaders($action = NULL, $type = NULL) {
+    if ($type == CRM_Core_Selector_Controller::EXPORT) {
+      $exportHeaders = [
+        ts('Page Type'),
+        ts('Page Name'),
+        ts('Visit Date'),
+        ts('Visit State'),
+        ts('Referrer Type'),
+        ts('Referrer Network'),
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_term',
+        'utm_content',
+        ts('Referrer URL'),
+        ts('Landing Page'),
+        ts('Referenced Record'),
+      ];
+      return $exportHeaders;
+    }
     if (!isset($this->_columnHeaders)) {
       $this->_columnHeaders = [
         [
@@ -384,6 +406,9 @@ class CRM_Track_Selector_Track extends CRM_Core_Selector_Base implements CRM_Cor
    * @return array the total number of rows for this action
    */
   public function &getRows($action, $offset, $rowCount, $sort, $output = NULL) {
+    if ($output == CRM_Core_Selector_Controller::EXPORT) {
+      return $this->buildExportRows($offset, $rowCount, $sort);
+    }
     $dao = $this->getQuery('*', NULL, $offset, $rowCount, $sort);
 
     $result = [];
@@ -462,6 +487,85 @@ class CRM_Track_Selector_Track extends CRM_Core_Selector_Base implements CRM_Cor
       }
     }
     return $results;
+  }
+
+  /**
+   * Build plain-text rows for spreadsheet export.
+   *
+   * @param int $offset
+   * @param int $rowCount
+   * @param mixed $sort
+   *
+   * @return array
+   */
+  private function buildExportRows($offset, $rowCount, $sort = NULL) {
+    $dao = $this->getQuery('*', NULL, $offset, $rowCount, $sort);
+
+    $rows = [];
+    $pageTables = [];
+    $recordTables = [];
+
+    while ($dao->fetch()) {
+      $rowId = $dao->id;
+      if (empty($dao->referrer_type)) {
+        $dao->referrer_type = 'unknown';
+      }
+      $rows[$rowId] = [
+        'page_type'       => $this->_pageTypes[$dao->page_type] ?? $dao->page_type,
+        'page_title'      => $dao->page_id,
+        'visit_date'      => CRM_Utils_Date::customFormat($dao->visit_date),
+        'state'           => $this->_trackState[$dao->state] ?? '',
+        'referrer_type'   => $this->_referrerTypes[$dao->referrer_type] ?? $dao->referrer_type,
+        'referrer_network' => $dao->referrer_network ?? '',
+        'utm_source'      => $dao->utm_source ?? '',
+        'utm_medium'      => $dao->utm_medium ?? '',
+        'utm_campaign'    => $dao->utm_campaign ?? '',
+        'utm_term'        => $dao->utm_term ?? '',
+        'utm_content'     => $dao->utm_content ?? '',
+        'referrer_url'    => $dao->referrer_url ?? '',
+        'landing'         => $dao->landing ?? '',
+        'entity_id'       => '',
+      ];
+      $pageTables[$dao->page_type][$dao->page_id][$rowId] = $rowId;
+      if (!empty($dao->entity_table) && !empty($dao->entity_id)) {
+        $recordTables[$dao->entity_table][$dao->entity_id][$rowId] = $rowId;
+      }
+    }
+
+    // Batch-fetch page titles to avoid N+1 queries
+    foreach ($pageTables as $table => $pages) {
+      $pageIds = CRM_Utils_Array::implode(',', array_map('intval', array_keys($pages)));
+      if (!$pageIds) {
+        continue;
+      }
+      $pageDAO = CRM_Core_DAO::executeQuery("SELECT id, title FROM $table WHERE id IN($pageIds)");
+      while ($pageDAO->fetch()) {
+        foreach ($pages[$pageDAO->id] as $rowId) {
+          $rows[$rowId]['page_title'] = $pageDAO->title;
+        }
+      }
+    }
+
+    // Batch-fetch contact IDs (no sort_name to avoid PII in plain export)
+    foreach ($recordTables as $table => $records) {
+      $entityIds = CRM_Utils_Array::implode(',', array_map('intval', array_keys($records)));
+      if (!$entityIds) {
+        continue;
+      }
+      if ($table === 'civicrm_contact') {
+        $recordDAO = CRM_Core_DAO::executeQuery("SELECT id, id AS cid FROM $table WHERE id IN($entityIds)");
+      }
+      else {
+        $recordDAO = CRM_Core_DAO::executeQuery("SELECT id, contact_id AS cid FROM $table WHERE id IN($entityIds)");
+      }
+      while ($recordDAO->fetch()) {
+        foreach ($records[$recordDAO->id] as $rowId) {
+          $rows[$rowId]['entity_id'] = $recordDAO->cid;
+        }
+      }
+    }
+
+    return $rows;
   }
 
   /**
@@ -559,6 +663,51 @@ class CRM_Track_Selector_Track extends CRM_Core_Selector_Base implements CRM_Cor
       $where[] = "entity_table = %14";
       $args[14] = [$this->_entityTable, 'String'];
     }
+    if ($this->_referrerUrl) {
+      $where[] = "referrer_url LIKE %15";
+      $args[15] = ['%' . $this->_referrerUrl . '%', 'String'];
+    }
+    if ($this->_landing) {
+      $where[] = "landing LIKE %16";
+      $args[16] = ['%' . $this->_landing . '%', 'String'];
+    }
+    if ($this->_pageTitle) {
+      $titleParam = [1 => ['%' . $this->_pageTitle . '%', 'String']];
+      $allPageTables = [
+        'civicrm_contribution_page',
+        'civicrm_event',
+        'civicrm_uf_group',
+      ];
+      // When page_type is already filtered, only search that table
+      $searchTables = ($this->_pageType && in_array($this->_pageType, $allPageTables))
+        ? [$this->_pageType]
+        : $allPageTables;
+
+      $pageConds = [];
+      foreach ($searchTables as $table) {
+        $idDao = CRM_Core_DAO::executeQuery("SELECT id FROM {$table} WHERE title LIKE %1", $titleParam);
+        $ids = [];
+        while ($idDao->fetch()) {
+          $ids[] = (int)$idDao->id;
+        }
+        if (!empty($ids)) {
+          $idList = implode(',', $ids);
+          if (count($searchTables) === 1) {
+            $pageConds[] = "page_id IN ({$idList})";
+          }
+          else {
+            $pageConds[] = "(page_type = '{$table}' AND page_id IN ({$idList}))";
+          }
+        }
+      }
+
+      if (!empty($pageConds)) {
+        $where[] = '(' . implode(' OR ', $pageConds) . ')';
+      }
+      else {
+        $where[] = '1 = 0';
+      }
+    }
 
     $where = CRM_Utils_Array::implode(" AND ", $where);
 
@@ -591,6 +740,7 @@ class CRM_Track_Selector_Track extends CRM_Core_Selector_Base implements CRM_Cor
    *   Name of the file.
    */
   public function getExportFileName($output = 'csv') {
+    return date('Ymd_') . 'traffic_source.xlsx';
   }
 
   /**
@@ -669,6 +819,9 @@ class CRM_Track_Selector_Track extends CRM_Core_Selector_Base implements CRM_Cor
             case 'entity_id':
               $filters[$name]['value_display'] = $value;
               // no break
+            case 'referrer_url':
+            case 'landing':
+            case 'page_title':
             case 'utm_source':
             case 'utm_medium':
             case 'utm_campaign':

--- a/CRM/Track/Selector/Track.php
+++ b/CRM/Track/Selector/Track.php
@@ -615,7 +615,9 @@ class CRM_Track_Selector_Track extends CRM_Core_Selector_Base implements CRM_Cor
       else {
         if ($this->_entityId == '%') {
           $where[] = "entity_id IS NOT NULL";
-          $args[5] = [0, 'Integer'];
+        }
+        elseif ($this->_entityId == 'null') {
+          $where[] = "entity_id IS NULL";
         }
         elseif (is_array($this->_entityId)) {
           $where[] = "entity_id IN (%5)";
@@ -817,8 +819,17 @@ class CRM_Track_Selector_Track extends CRM_Core_Selector_Base implements CRM_Cor
               $filters[$name]['value_display'] = $this->_trackState[$value];
               break;
             case 'entity_id':
-              $filters[$name]['value_display'] = $value;
-              // no break
+              if ($value == '%') {
+                $filters[$name]['value_display'] = ts('Has Record');
+              }
+              elseif ($value == 'null') {
+                $filters[$name]['value_display'] = ts('No Record');
+              }
+              else {
+                $filters[$name]['value_display'] = $value;
+              }
+              break;
+            // no break
             case 'referrer_url':
             case 'landing':
             case 'page_title':

--- a/templates/CRM/Track/Page/Track.tpl
+++ b/templates/CRM/Track/Page/Track.tpl
@@ -1,15 +1,164 @@
+<style>{literal}
+.track-filter-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+.track-filter-item  {
+  display: flex;
+  flex-direction: column;
+  width: 180px;
+}
+input[type="text"].form-text{
+  width:190px
+}
+.track-filter-item label {
+  font-weight: bold;
+  margin-bottom: 4px;
+  white-space: nowrap;
+}
+.track-filter-item input,
+.track-filter-item select {
+  box-sizing: border-box;
+}
+
+.crm-form-block label {
+  font-weight: bold;
+}
+{/literal}</style>
 <div class="crm-block crm-form-block">
-  {if !$filters.start}
-    {ts}Start Date{/ts}: <input formattype="activityDate" addtime="1" timeformat="2" startoffset="20" endoffset="0" format="yy-mm-dd" name="start" type="text" id="start" class="form-text dateplugin" value="{$defaultStartDate}">
-    {include file="CRM/common/jcalendar.tpl" elementId=start action=4}
-  {/if}
-  {if !$filters.end}
-    {ts}End Date{/ts}: <input formattype="activityDate" addtime="1" timeformat="2" startoffset="20" endoffset="0" format="yy-mm-dd" name="end" type="text" id="end" class="form-text form-text dateplugin">
-    {include file="CRM/common/jcalendar.tpl" elementId=end action=4}
-  {/if}
-  {if !$filters.start || !$filters.end}
-    <a id="submit-filter" class="button" href="{$drill_down_base}"><i class="zmdi zmdi-search-in-page"></i>{ts}Filter{/ts}</a>
-  {/if}
+  <div class="track-filter-grid">
+    {if !$filters.start}
+    <div class="track-filter-item">
+      <label>{ts}Start Date{/ts}</label>
+      <input formattype="activityDate" addtime="1" timeformat="2" startoffset="20" endoffset="0" format="yy-mm-dd" name="start" type="text" id="start" class="form-text dateplugin" value="{$defaultStartDate}">
+      {include file="CRM/common/jcalendar.tpl" elementId=start action=4}
+    </div>
+    {/if}
+    {if !$filters.end}
+    <div class="track-filter-item">
+      <label>{ts}End Date{/ts}</label>
+      <input formattype="activityDate" addtime="1" timeformat="2" startoffset="20" endoffset="0" format="yy-mm-dd" name="end" type="text" id="end" class="form-text dateplugin">
+      {include file="CRM/common/jcalendar.tpl" elementId=end action=4}
+    </div>
+    {/if}
+    
+    <div class="track-filter-item">
+      <label>{ts}Page Type{/ts}</label>
+      <select id="filter-ptype" class="form-select">
+        <option value="">-- {ts}All{/ts} --</option>
+        {foreach from=$pageTypes item=label key=value}
+          <option value="{$value}"{if $currentPageType eq $value} selected="selected"{/if}>{$label}</option>
+        {/foreach}
+      </select>
+    </div>
+    {if !$filters.page_title}
+    <div class="track-filter-item">
+      <label>{ts}Page Name{/ts}</label>
+      <input type="text" id="filter-page-title" class="form-text">
+    </div>
+    {/if}
+    {if !$filters.state}
+    <div class="track-filter-item">
+      <label>{ts}Visit State{/ts}</label>
+      <select id="filter-state" class="form-select">
+        <option value="">-- {ts}Select{/ts} --</option>
+        {foreach from=$trackStates item=label key=value}
+          <option value="{$value}">{$label}</option>
+        {/foreach}
+      </select>
+    </div>
+    {/if}
+     
+  </div>
+  <div class="crm-accordion-wrapper crm-accordion-open">
+    <div class="crm-accordion-header">
+      <div class="zmdi crm-accordion-pointer"></div>
+      {ts}Traffic Source{/ts}
+    </div>
+    <div class="crm-accordion-body">
+      <table class="form-layout">
+        <tbody>
+          <tr>
+            {if !$filters.rtype}
+            <td>
+              <div class="track-filter-item">
+                <label>{ts}Referrer Type{/ts}</label>
+                <select id="filter-rtype" class="form-select">
+                <option value="">-- {ts}Select{/ts} --</option>
+                  {foreach from=$referrerTypes item=label key=value}
+                <option value="{$value}">{$label}</option>
+                  {/foreach}
+              </select>
+              </div>
+            </td>
+            {/if}
+            {if !$filters.rnetwork}
+            <td>
+              <label>{ts}Referrer Network{/ts}</label><br>
+              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-rnetwork" class="form-text"></div>
+            </td>
+            {else}<td></td>{/if}
+           
+            {if !$filters.referrer_url}
+            <td>
+              <label>{ts}Referrer URL{/ts}</label><br>
+              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-referrer-url" class="form-text"></div>
+            </td>
+            {else}<td></td>{/if}
+            {if !$filters.landing}
+            <td>
+              <label>{ts}Landing Page{/ts}</label><br>
+              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-landing" class="form-text"></div>
+            </td>
+            {else}<td></td>{/if}
+            {if !$filters.entity_id}
+            <td>
+              <label>{ts}Entity ID{/ts}</label><br>
+              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-entity-id" class="form-text"></div>
+            </td>
+            {else}<td></td>{/if}
+            
+          </tr>
+          <tr>
+            {if !$filters.utm_source}
+            <td>
+              <label>UTM Source</label><br>
+              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-utm-source" class="form-text"></div>
+            </td>
+            {else}<td></td>{/if}
+             {if !$filters.utm_medium}
+            <td>
+              <label>UTM Medium</label><br>
+              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-utm-medium" class="form-text"></div>
+            </td>
+            {else}<td></td>{/if}
+            {if !$filters.utm_campaign}
+            <td>
+              <label>UTM Campaign</label><br>
+              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-utm-campaign" class="form-text"></div>
+            </td>
+            {else}<td></td>{/if}
+            {if !$filters.utm_term}
+            <td>
+              <label>UTM Term</label><br>
+              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-utm-term" class="form-text"></div>
+            </td>
+            {else}<td></td>{/if}
+            {if !$filters.utm_content}
+            <td>
+              <label>UTM Content</label><br>
+              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-utm-content" class="form-text"></div>
+            </td>
+            {else}<td></td>{/if}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <a id="submit-filter" class="button" href="{$drill_down_base}"><i class="zmdi zmdi-search-in-page"></i>{ts}Filter{/ts}</a>
+  <a id="export-track" class="button" href="{$drill_down_base}&output=csv">{ts}Export Spreadsheet{/ts}</a>
 </div>
 {if $filters}
 <div class="crm-block crm-form-block">
@@ -105,19 +254,52 @@
 {literal}
 <script type="text/javascript">
 cj(function() {
-  cj('a#submit-filter').click(function(e){
-    var href = cj(this).attr('href');
+  var filterFieldMap = {
+    'ptype': '#filter-ptype',
+    'page_title': '#filter-page-title',
+    'start': '#start',
+    'end': '#end',
+    'rtype': '#filter-rtype',
+    'rnetwork': '#filter-rnetwork',
+    'state': '#filter-state',
+    'entity_id': '#filter-entity-id',
+    'referrer_url': '#filter-referrer-url',
+    'landing': '#filter-landing',
+    'utm_source': '#filter-utm-source',
+    'utm_medium': '#filter-utm-medium',
+    'utm_campaign': '#filter-utm-campaign',
+    'utm_term': '#filter-utm-term',
+    'utm_content': '#filter-utm-content'
+  };
+  function buildFilterUrl(href) {
     var appendQuery = [];
-    if (cj('#start').val()) {
-      appendQuery.push('start='+cj('#start').val());
+    cj.each(filterFieldMap, function(param, selector) {
+      var el = cj(selector);
+      if (!el.length || !el.val()) {
+        return;
+      }
+      // ptype is always in the base URL, replace it instead of appending
+      if (param === 'ptype') {
+        href = href.replace(/ptype=[^&]*/, 'ptype=' + encodeURIComponent(el.val()));
+        href = href.replace(/pid=[^&]*/, 'pid=');
+        return;
+      }
+      if (href.indexOf(param + '=') === -1) {
+        appendQuery.push(param + '=' + encodeURIComponent(el.val()));
+      }
+    });
+    if (appendQuery.length > 0) {
+      href += '&' + appendQuery.join('&');
     }
-    if (cj('#end').val()) {
-      appendQuery.push('end='+cj('#end').val());
-    }
-    if (appendQuery.length > 0){
-      href += '&'+appendQuery.join('&');
-      cj(this).attr('href', href); 
-    }
+    return href;
+  }
+  cj('a#submit-filter').click(function(e){
+    var href = buildFilterUrl(cj(this).attr('href'));
+    cj(this).attr('href', href);
+  });
+  cj('a#export-track').click(function(e){
+    var href = buildFilterUrl(cj(this).attr('href'));
+    cj(this).attr('href', href);
   });
   cj().crmaccordions();
   cj('.crm-accordion-header').click(function() {

--- a/templates/CRM/Track/Page/Track.tpl
+++ b/templates/CRM/Track/Page/Track.tpl
@@ -1,4 +1,11 @@
 <style>{literal}
+.export-confirm-dialog {
+  position: fixed ;
+  top: 210px;
+  left: 50%;
+  transform: translate(-50%, -50%) ;
+  margin: 0 ;
+}
 .track-filter-grid {
   display: flex;
   flex-wrap: wrap;
@@ -116,7 +123,7 @@ input[type="text"].form-text{
             {if !$filters.entity_id}
             <td>
               <label>{ts}Entity ID{/ts}</label><br>
-              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-entity-id" class="form-text"></div>
+              <div class="crm-form-elem crm-form-textfield"><input type="text" id="filter-entity-id" class="form-text" placeholder="{ts}ID or 'null'{/ts}"></div>
             </td>
             {else}<td></td>{/if}
             
@@ -159,6 +166,9 @@ input[type="text"].form-text{
   </div>
   <a id="submit-filter" class="button" href="{$drill_down_base}"><i class="zmdi zmdi-search-in-page"></i>{ts}Filter{/ts}</a>
   <a id="export-track" class="button" href="{$drill_down_base}&output=csv">{ts}Export Spreadsheet{/ts}</a>
+</div>
+<div id="dialog-confirm-export" title="{ts}Confirm Export?{/ts}" style="display:none;">
+  <p>{ts}Are you sure you want to export this data?{/ts}</p>
 </div>
 {if $filters}
 <div class="crm-block crm-form-block">
@@ -297,9 +307,30 @@ cj(function() {
     var href = buildFilterUrl(cj(this).attr('href'));
     cj(this).attr('href', href);
   });
-  cj('a#export-track').click(function(e){
-    var href = buildFilterUrl(cj(this).attr('href'));
-    cj(this).attr('href', href);
+  var exportHref = '';
+  cj('#dialog-confirm-export').dialog({
+    autoOpen: false,
+    resizable: false,
+    width: 450,
+    modal: true,
+    dialogClass: 'export-confirm-dialog',
+    open: function() {
+    cj(this).dialog('widget').removeClass('ui-front');
+    },
+    buttons: {
+      '{/literal}{ts}Confirm Export{/ts}{literal}': function() {
+        cj(this).dialog('close');
+        window.location.href = exportHref;
+      },
+      '{/literal}{ts}Cancel{/ts}{literal}': function() {
+        cj(this).dialog('close');
+      }
+    }
+  });
+  cj('a#export-track').click(function(e) {
+    e.preventDefault();
+    exportHref = buildFilterUrl(cj(this).attr('href'));
+    cj('#dialog-confirm-export').dialog('open');
   });
   cj().crmaccordions();
   cj('.crm-accordion-header').click(function() {


### PR DESCRIPTION
「流量來源」的匯出功能
新增確認box，防止誤觸

【測試完成】
- AC-1：當使用者點擊「匯出試算表」按鈕，且符合篩選條件的總筆數 < 10,000 時，系統應依當下篩選條件直接下載一份試算表（xlsx），筆數與頁面顯示的總筆數一致。
- AC-2：匯出的試算表（xlsx）欄位應包含：頁面類型、頁面名稱、造訪日期、造訪狀態、來源類型、來源網絡、utm_source、utm_medium、utm_campaign、utm_term、utm_content、來源網址（完整 URL）、著陸頁（完整路徑）、關聯紀錄（CiviCRM Contact ID 數字，無 HTML），且所有欄位內容不含任何 HTML 標籤。
- AC-3：當流量來源報表頁未設定任何篩選條件（預設顯示近 3 個月資料）時，點擊「匯出試算表」，系統應匯出近 3 個月的全部流量明細，不應匯出超出預設日期範圍的資料。
- AC-4：當流量來源報表頁已套用篩選條件（如 rtype=social）時，匯出的試算表應只包含符合該條件的記錄。
- AC-5：當記錄的 entity_id 為 null（未完成轉化的流量），系統應仍將該筆記錄匯出，「關聯紀錄」欄位留空。
- AC-8：當系統安全設定「匯出 Excel 密碼保護」啟用（decryptExcelOption = 1 或 2）時，直接匯出（< 10,000 筆）的 xlsx 檔案應已套用對應密碼保護（選項 1：匯出者主要 Email；選項 2：管理員設定的通用密碼）。
- AC-9：當系統安全設定「匯出 Excel 密碼保護」停用（decryptExcelOption = 0）時，下載的 xlsx 檔案不應有密碼保護，可直接開啟。

【待測試】
- AC-6：當符合篩選條件的總筆數 ≥ 10,000 且 < 100,000 時，點擊「匯出試算表」後，系統應轉為背景批次作業，導向批次作業頁面，完成後寄 email 通知使用者，下載檔案為 xlsx 格式。
- AC-7：當符合篩選條件的總筆數 ≥ 100,000 時，系統應轉為背景批次作業，完成後下載檔案為 CSV 格式（非 xlsx）。