### PR TITLE
Develop 47462 trxn_id repeat bug

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1048,7 +1048,7 @@ cj(function() {
       }
       $dupDao = CRM_Core_DAO::executeQuery($dupQuery, $dupParams);
       if ($dupDao->fetch()) {
-        $errorMsg['trxn_id'] = ts('此交易編號已存在於資料庫。');
+        $errorMsg['trxn_id'] = ts('Transaction ID already exists in Database.');
       }
     }
 

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1022,6 +1022,36 @@ cj(function() {
       $errorMsg['contribution_status_id'] = ts("Please select a valid payment status before updating.");
     }
 
+    // validate trxn_id uniqueness when record_contribution is checked (AC-1, AC-2, AC-3)
+    if (CRM_Utils_Array::value('record_contribution', $values) &&
+      !empty($values['trxn_id'])
+    ) {
+      $trxnId = $values['trxn_id'];
+      $excludeContributionId = NULL;
+
+      // AC-3: When editing a participant that already has a payment linked,
+      // exclude that participant's own contribution from the duplicate check.
+      if ($self->_id && $self->_paymentId) {
+        $excludeContributionId = CRM_Core_DAO::getFieldValue(
+          'CRM_Event_DAO_ParticipantPayment',
+          $self->_id,
+          'contribution_id',
+          'participant_id'
+        );
+      }
+
+      $dupQuery = "SELECT id FROM civicrm_contribution WHERE trxn_id = %1";
+      $dupParams = [1 => [$trxnId, 'String']];
+      if ($excludeContributionId) {
+        $dupQuery .= " AND id != %2";
+        $dupParams[2] = [$excludeContributionId, 'Integer'];
+      }
+      $dupDao = CRM_Core_DAO::executeQuery($dupQuery, $dupParams);
+      if ($dupDao->fetch()) {
+        $errorMsg['trxn_id'] = ts('此交易編號已存在於資料庫。');
+      }
+    }
+
     // do the amount validations.
     //skip for update mode since amount is freeze, CRM-6052
     if ((

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1022,14 +1022,12 @@ cj(function() {
       $errorMsg['contribution_status_id'] = ts("Please select a valid payment status before updating.");
     }
 
-    // validate trxn_id uniqueness when record_contribution is checked (AC-1, AC-2, AC-3)
     if (CRM_Utils_Array::value('record_contribution', $values) &&
       !empty($values['trxn_id'])
     ) {
       $trxnId = $values['trxn_id'];
       $excludeContributionId = NULL;
 
-      // AC-3: When editing a participant that already has a payment linked,
       // exclude that participant's own contribution from the duplicate check.
       if ($self->_id && $self->_paymentId) {
         $excludeContributionId = CRM_Core_DAO::getFieldValue(


### PR DESCRIPTION
建立參加者「記錄付款」功能未檢查交易編號重複

情境與影響：
情境敘述：
發生流程／情境：後台人員手動新增參加者，或編輯尚無付款關聯的既有參加者，勾選「記錄付款？」（record_contribution）並輸入已存在的「交易編號」（trxn_id）後儲存。
實際現象（與預期的落差）：系統先建立或保留參加者，再於建立捐款時因交易編號重複而失敗，畫面顯示未預期錯誤；新增情境可能留下沒有捐款及活動費用付款關聯的孤立參加者。
對使用者的困擾（why）：後台人員無法在送出前理解錯誤原因，且畫面顯示失敗時仍可能留下部分資料，必須再由客服或工程辨識及人工處理，容易造成活動參加者與實收紀錄不一致。

驗收標準（AC）：
AC-1：當後台新增參加者，或編輯尚未有付款關聯、因此會走新增付款流程的既有參加者，並勾選「記錄付款？」（record_contribution）、於「交易編號」（trxn_id）輸入已存在於任一既有捐款紀錄的值後送出時，系統應在表單驗證階段阻擋儲存，於「交易編號」欄位顯示錯誤訊息「此交易編號已存在於資料庫。」，且不得新增或異動參加者、捐款、活動費用付款關聯紀錄。

AC-2：當「交易編號」（trxn_id）留空，或輸入值未與既有捐款紀錄重複時，系統應維持現行行為成功儲存，並完整建立或更新參加者、捐款與活動費用付款關聯，不出現未預期錯誤畫面。

AC-3：當編輯已有付款關聯的參加者，且「交易編號」（trxn_id）等於該參加者自身連結捐款的交易編號時，系統不得誤判為重複交易編號而阻擋儲存。

測試成功紀錄：http://pm.netivism.com.tw/issues/47462#note-5